### PR TITLE
chore: remove SonarQube/SonarCloud integration

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar.projectKey=maticnetwork_matic-cli_AYWWxKe_oHLw1uOg0pqh


### PR DESCRIPTION
Part of the org-wide SonarQube/SonarCloud deprecation (consolidating on CodeQL + GitHub Advanced Security).

## Changes
- Removed `sonar-project.properties` (the only SonarQube/SonarCloud artifact present on the default branch).

## Notes
- No Sonar-only workflow exists on `master`; the `ci.yml` and `codeql.yml` workflows contain no Sonar steps and were left untouched.
- No SONAR_TOKEN / SONAR_HOST_URL env vars, README badges, or package.json scripts referenced Sonar on this branch — nothing else to remove.
- Repository secrets were not touched.
- `git grep -in sonar` is clean after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)